### PR TITLE
Update requirement and remove acados install for work shop

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 channels:
 - conda-forge
 dependencies:
-- python ==3.11
-- bioptim >=3.0.0
+- python ==3.10
+- bioptim ==3.0.0

--- a/postBuild
+++ b/postBuild
@@ -5,9 +5,6 @@ git clone https://github.com/pyomeca/bioptim.git
 
 # Install ACADOS
 source activate notebook
-cd bioptim/external
-./acados_install_linux.sh
-cd ../..
 
 # Keep only the examples
 mv bioptim/examples examples 


### PR DESCRIPTION
With old requirement binder did not build. Also I remove acados installation because it is not useful for our workshop and it take some time to install we can put it back after. 